### PR TITLE
main - fix typo in header labels

### DIFF
--- a/mbgui/main.py
+++ b/mbgui/main.py
@@ -87,7 +87,7 @@ class Directories:
         self._executor = executor
         self._icons = icons
         self._model = QtGui.QStandardItemModel()
-        self._model.setHorizontalHeaderLabels(['Directory', 'Unseed', 'Total'])
+        self._model.setHorizontalHeaderLabels(['Directory', 'Unseen', 'Total'])
         self._get_directories(paths)
 
     @property


### PR DESCRIPTION
Discovered this typo from the screenshot you added ;)